### PR TITLE
Add Log trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Nightly Rust
       run: |
         rustup install nightly
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Nightly Rust
       run: |
         rustup install nightly
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Nightly Rust
       run: |
         rustup install nightly
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Nightly Rust
       run: |
         rustup install nightly
@@ -65,6 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
-    - name: Use Nightly Rust
-      run: |
-        rustup install nightly
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Run Tests
       run: cargo test
   Miri:
@@ -29,12 +26,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    - name: Use Nightly Rust
-      run: |
-        rustup install nightly
-        rustup default nightly
-    - name: Install Miri
-      run: rustup component add miri
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri
     - name: Run Test With Miri
       run: cargo miri test
   Clippy:
@@ -42,12 +36,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    - name: Use Nightly Rust
-      run: |
-        rustup install nightly
-        rustup default nightly
-    - name: Install Clippy
-      run: rustup component add clippy
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: clippy
     - name: Clippy
       run: cargo clippy --all-targets
   Docs:
@@ -55,10 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
-    - name: Use Nightly Rust
-      run: |
-        rustup install nightly
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Check docs
       run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
   Rustfmt:
@@ -66,5 +54,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -11,7 +11,8 @@ fn main() {
     let initial_config = Arc::new(initial_config);
 
     // Create a new left-right data structure from the configuration.
-    let (mut writer, handle) = left_right::new_cloned::<_, Vec<_>>(initial_config);
+    let (mut writer, handle) =
+        left_right::new_cloned::<_, Option<OverwriteOperation<_>>>(initial_config);
 
     // Do something useful...
     let reader = handle.into_reader();

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -11,7 +11,7 @@ fn main() {
     let initial_config = Arc::new(initial_config);
 
     // Create a new left-right data structure from the configuration.
-    let (mut writer, handle) = left_right::new_cloned(initial_config);
+    let (mut writer, handle) = left_right::new_cloned::<_, Vec<_>>(initial_config);
 
     // Do something useful...
     let reader = handle.into_reader();

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -68,19 +68,29 @@ use std::hash::{BuildHasher, Hash};
 use std::ops::Deref;
 
 /// Create a new hashmap.
-pub fn new<K, V>() -> (Writer<K, V>, Handle<K, V>) {
+pub fn new<K, V>() -> (Writer<K, V>, Handle<K, V>)
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+{
     with_hasher(RandomState::default())
 }
 
 /// Creates an empty hashmap with at least the specified `capacity`.
-pub fn with_capacity<K, V>(capacity: usize) -> (Writer<K, V>, Handle<K, V>) {
+pub fn with_capacity<K, V>(capacity: usize) -> (Writer<K, V>, Handle<K, V>)
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+{
     with_capacity_and_hasher(capacity, RandomState::default())
 }
 
 /// Creates an empty hashmap which will use the given hash builder to hash keys.
 pub fn with_hasher<K, V, S>(hasher: S) -> (Writer<K, V, S>, Handle<K, V, S>)
 where
-    S: Clone,
+    K: Clone + Eq + Hash,
+    V: Clone,
+    S: BuildHasher + Clone,
 {
     let left = HashMap::with_hasher(hasher.clone());
     let right = HashMap::with_hasher(hasher);
@@ -96,7 +106,9 @@ pub fn with_capacity_and_hasher<K, V, S>(
     hasher: S,
 ) -> (Writer<K, V, S>, Handle<K, V, S>)
 where
-    S: Clone,
+    K: Clone + Eq + Hash,
+    V: Clone,
+    S: BuildHasher + Clone,
 {
     let left = HashMap::with_capacity_and_hasher(capacity, hasher.clone());
     let right = HashMap::with_capacity_and_hasher(capacity, hasher);
@@ -136,7 +148,7 @@ where
 /// assert_eq!(reader.len(), 1);
 /// ```
 pub struct Writer<K, V, S = RandomState> {
-    inner: crate::Writer<HashMap<K, V, S>, Operation<K, V>>,
+    inner: crate::Writer<HashMap<K, V, S>, Vec<Operation<K, V>>>,
 }
 
 /// Writer [operation] for [`Writer`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::task::{self, Poll};
 
 pub mod operation;
-pub use operation::Operation;
+pub use operation::{Log, Operation};
 
 pub mod hashmap;
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -128,9 +128,7 @@ pub unsafe trait Log<T>: Sized {
     ///
     /// All operations in the log must be applied to ensure both copies are in
     /// sync.
-    fn apply_and_clear(&mut self, target: &mut T)
-    where
-        Self: Sized;
+    fn apply_and_clear(&mut self, target: &mut T);
 }
 
 unsafe impl<O, T> Log<T> for Vec<O>
@@ -151,10 +149,7 @@ where
         self.push(operation);
     }
 
-    fn apply_and_clear(&mut self, target: &mut T)
-    where
-        Self: Sized,
-    {
+    fn apply_and_clear(&mut self, target: &mut T) {
         for operation in self.drain(..) {
             operation.apply_again(target);
         }
@@ -181,10 +176,7 @@ where
         *self = Some(operation);
     }
 
-    fn apply_and_clear(&mut self, target: &mut T)
-    where
-        Self: Sized,
-    {
+    fn apply_and_clear(&mut self, target: &mut T) {
         if let Some(operation) = self.take() {
             operation.apply_again(target)
         }

--- a/tests/left_right.rs
+++ b/tests/left_right.rs
@@ -278,6 +278,22 @@ fn overwrite_operation_works() {
     assert_eq!(unsafe { *reader.read().deref() }, "test");
 }
 
+#[test]
+fn overwrite_operation_log_works() {
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Option<OverwriteOperation<_>>>("", "") };
+    let reader = handle.into_reader();
+
+    writer.apply(OverwriteOperation::new("test"));
+    writer.blocking_flush();
+    assert_eq!(unsafe { *reader.read().deref() }, "test");
+
+    writer.apply(OverwriteOperation::new("test2"));
+    writer.apply(OverwriteOperation::new("test3"));
+    writer.blocking_flush();
+    assert_eq!(unsafe { *reader.read().deref() }, "test3");
+}
+
 fn new_count_waker() -> (task::Waker, AwokenCount) {
     let inner = Arc::new(WakerInner {
         count: AtomicUsize::new(0),

--- a/tests/left_right.rs
+++ b/tests/left_right.rs
@@ -21,7 +21,7 @@ unsafe impl Operation<String> for TestOperation {
 
 #[test]
 fn read_guard_map() {
-    let (_, handle) = left_right::new_cloned::<_, TestOperation>(String::from("Hello"));
+    let (_, handle) = left_right::new_cloned::<_, Vec<TestOperation>>(String::from("Hello"));
     let reader = handle.into_reader();
 
     unsafe { need_bytes(reader.read().map(|s| s.as_bytes()).deref()) };
@@ -32,7 +32,7 @@ fn read_guard_map() {
 
 #[test]
 fn read_guard_map_panic() {
-    let (_, handle) = left_right::new_cloned::<_, TestOperation>(String::from("Hello"));
+    let (_, handle) = left_right::new_cloned::<_, Vec<TestOperation>>(String::from("Hello"));
     let reader = handle.into_reader();
 
     match panic::catch_unwind(|| unsafe { reader.read().map(|_| -> &str { panic!("oops") }) }) {
@@ -46,7 +46,7 @@ fn read_guard_map_panic() {
 
 #[test]
 fn writer_apply_does_not_apply_to_reader_copy() {
-    let (mut writer, handle) = left_right::new_from_default::<String, _>();
+    let (mut writer, handle) = left_right::new_from_default::<String, Vec<_>>();
     let reader = handle.into_reader();
 
     writer.apply(TestOperation::Append("test"));
@@ -55,7 +55,7 @@ fn writer_apply_does_not_apply_to_reader_copy() {
 
 #[test]
 fn writer_apply_to_reader_copy_does_not_apply_to_writer_copy() {
-    let (mut writer, handle) = left_right::new_cloned(String::new());
+    let (mut writer, handle) = left_right::new_cloned::<_, Vec<_>>(String::new());
     let reader = handle.into_reader();
 
     unsafe { writer.apply_to_reader_copy(TestOperation::Append("test")) };
@@ -65,7 +65,8 @@ fn writer_apply_to_reader_copy_does_not_apply_to_writer_copy() {
 
 #[test]
 fn writer_blocking_flush_shows_changes_to_reader_copy() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
     let reader = handle.into_reader();
 
     writer.apply(TestOperation::Append("test"));
@@ -75,7 +76,8 @@ fn writer_blocking_flush_shows_changes_to_reader_copy() {
 
 #[test]
 fn writer_blocking_flush_shows_changes_to_reader_copy_on_different_thread() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
 
     // Stages:
     // 1. Read guard held.
@@ -112,7 +114,8 @@ fn writer_blocking_flush_shows_changes_to_reader_copy_on_different_thread() {
 
 #[test]
 fn writer_flush_shows_changes_to_reader_copy() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
     let reader = handle.into_reader();
 
     writer.apply(TestOperation::Append("test"));
@@ -129,7 +132,8 @@ fn writer_flush_shows_changes_to_reader_copy() {
 
 #[test]
 fn writer_flush_shows_changes_to_reader_copy_on_different_thread() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
 
     // Stages:
     // 1. Read guard held.
@@ -176,7 +180,8 @@ fn writer_flush_shows_changes_to_reader_copy_on_different_thread() {
 
 #[test]
 fn writer_flush_future_dropped() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
 
     // Stages:
     // 1. Read guard held.
@@ -216,7 +221,8 @@ fn writer_flush_future_dropped() {
 
 #[test]
 fn writer_flush_future_polled_many_times() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
     let reader = handle.into_reader();
 
     let read_guard = unsafe { reader.read() };
@@ -242,7 +248,8 @@ fn writer_flush_future_polled_many_times() {
 
 #[test]
 fn writer_flush_future_polled_after_completion() {
-    let (mut writer, handle) = unsafe { left_right::new(String::new(), String::new()) };
+    let (mut writer, handle) =
+        unsafe { left_right::new::<_, Vec<_>>(String::new(), String::new()) };
     let reader = handle.into_reader();
 
     writer.apply(TestOperation::Append("test"));
@@ -263,7 +270,7 @@ fn writer_flush_future_polled_after_completion() {
 
 #[test]
 fn overwrite_operation_works() {
-    let (mut writer, handle) = unsafe { left_right::new("", "") };
+    let (mut writer, handle) = unsafe { left_right::new::<_, Vec<_>>("", "") };
     let reader = handle.into_reader();
 
     writer.apply(OverwriteOperation::new("test"));

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -22,7 +22,7 @@ unsafe impl Operation<usize> for TestOperation {
 
 #[test]
 fn stress_test() {
-    let (mut writer, handle) = unsafe { left_right::new(0, 0) };
+    let (mut writer, handle) = unsafe { left_right::new::<_, Vec<_>>(0, 0) };
 
     let barrier = Arc::new(Barrier::new(READ_THREADS + 1));
     let handles: Vec<_> = (0..READ_THREADS)


### PR DESCRIPTION
This will replaces the Vec<O> in the Writer and allow for further optimisation, mainly not allocating a `Vec`.